### PR TITLE
Update README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ you need `-std=c++1z` and `-lstdc++fs` flags
 to enable C++17 standard and [filesystem](https://en.cppreference.com/w/cpp/experimental/fs) libraries.
 
 ```bash
-~$ g++ app.cpp -std=c++1z -lstdc++fs -O2 -I include -L lib -lOpenTimer -o app.out
+~$ g++ app.cpp -std=c++1z -O2 -I include -L lib -lOpenTimer -lpthread -o app.out "-lstdc++fs "
 ~$ ./app.out
 ```
 


### PR DESCRIPTION
Changed the command to build application on top of the OpenTimer headers and library.
Original:
~$ g++ app.cpp -std=c++1z -lstdc++fs -O2 -I include -L lib -lOpenTimer -o app.out
Updated:
~$ g++ app.cpp -std=c++1z -O2 -I include -L lib -lOpenTimer -lpthread -o app.out  "-lstdc++fs "

Application is not building without "-lstdc++fs " and -lpthread .
-lstdc++fs  should be in "-lstdc++fs ", otherwise error is occurring.