### PR TITLE
Fix build with new C++ compilers/libraries

### DIFF
--- a/main/shell/shell.cpp
+++ b/main/shell/shell.cpp
@@ -11,10 +11,10 @@ int main(int argc, char* argv[]) {
   auto flag_quiet {false};
   auto flag_version {false};
 
-  std::filesystem::path stdin_path;
-  std::filesystem::path stdout_path;
-  std::filesystem::path stderr_path;
-  std::filesystem::path log_path;
+  ot::filesystem::path stdin_path;
+  ot::filesystem::path stdout_path;
+  ot::filesystem::path stderr_path;
+  ot::filesystem::path log_path;
 
   app.add_flag  ("-q,--quiet",   flag_quiet,   "do not print the welcome on startup");
   app.add_flag  ("-v,--version", flag_version, "print version information and exit");

--- a/main/tau15/tau15.cpp
+++ b/main/tau15/tau15.cpp
@@ -8,14 +8,14 @@ int main(int argc, char* argv[]) {
     OT_LOGF("usage: ot-tau15 <file>.tau2015 <file>.timing <file>.ops output");
   }
 
-  std::filesystem::path tau2015 = argv[1];
-  std::filesystem::path timing = argv[2];
-  std::filesystem::path ops = argv[3];
-  std::filesystem::path output = argv[4];
-  std::filesystem::path early_celllib;
-  std::filesystem::path late_celllib;
-  std::filesystem::path spef;
-  std::filesystem::path verilog;
+  ot::filesystem::path tau2015 = argv[1];
+  ot::filesystem::path timing = argv[2];
+  ot::filesystem::path ops = argv[3];
+  ot::filesystem::path output = argv[4];
+  ot::filesystem::path early_celllib;
+  ot::filesystem::path late_celllib;
+  ot::filesystem::path spef;
+  ot::filesystem::path verilog;
 
   if(std::ifstream ifs(tau2015); ifs) {
     ifs >> early_celllib >> late_celllib >> spef >> verilog; 

--- a/main/tau18/tau18.cpp
+++ b/main/tau18/tau18.cpp
@@ -8,14 +8,14 @@ int main(int argc, char* argv[]) {
     OT_LOGF("usage: ot-tau18 <file>.tau2018 <file>.timing <file>.ops output");
   }
 
-  std::filesystem::path tau2018 = argv[1];
-  std::filesystem::path timing = argv[2];
-  std::filesystem::path ops = argv[3];
-  std::filesystem::path output = argv[4];
-  std::filesystem::path early_celllib;
-  std::filesystem::path late_celllib;
-  std::filesystem::path spef;
-  std::filesystem::path verilog;
+  ot::filesystem::path tau2018 = argv[1];
+  ot::filesystem::path timing = argv[2];
+  ot::filesystem::path ops = argv[3];
+  ot::filesystem::path output = argv[4];
+  ot::filesystem::path early_celllib;
+  ot::filesystem::path late_celllib;
+  ot::filesystem::path spef;
+  ot::filesystem::path verilog;
 
   if(std::ifstream ifs(tau2018); ifs) {
     ifs >> early_celllib >> late_celllib >> spef >> verilog; 

--- a/main/utility/utility.cpp
+++ b/main/utility/utility.cpp
@@ -1,7 +1,7 @@
 #include <ot/timer/timer.hpp>
 
 // Procedure: compress_spef
-void compress_spef(const std::filesystem::path& ori, const std::filesystem::path& cmp) {
+void compress_spef(const ot::filesystem::path& ori, const ot::filesystem::path& cmp) {
   
   // Open the spef file
   spef::Spef spef;
@@ -20,7 +20,7 @@ void compress_spef(const std::filesystem::path& ori, const std::filesystem::path
 }
 
 // Procedure: timing_to_sdc
-void timing_to_sdc(const std::filesystem::path& timing, const std::filesystem::path& sdc) {
+void timing_to_sdc(const ot::filesystem::path& timing, const ot::filesystem::path& sdc) {
   
   // Open the timing file and sdc output
   std::ifstream tfs(timing);
@@ -163,12 +163,12 @@ void timing_to_sdc(const std::filesystem::path& timing, const std::filesystem::p
 // ------------------------------------------------------------------------------------------------
 
 // Procedure: tau15_to_shell
-void tau15_to_shell(const std::filesystem::path& tau15, const std::filesystem::path& shell) {
+void tau15_to_shell(const ot::filesystem::path& tau15, const ot::filesystem::path& shell) {
 
-  std::filesystem::path early_celllib;
-  std::filesystem::path late_celllib;
-  std::filesystem::path spef;
-  std::filesystem::path verilog;
+  ot::filesystem::path early_celllib;
+  ot::filesystem::path late_celllib;
+  ot::filesystem::path spef;
+  ot::filesystem::path verilog;
 
   // open tau folder
   if(std::ifstream ifs(tau15); ifs) {
@@ -179,8 +179,8 @@ void tau15_to_shell(const std::filesystem::path& tau15, const std::filesystem::p
   }
 
   // Convert the timing to sdc
-  std::filesystem::path timing = tau15.stem().string() + ".timing";
-  std::filesystem::path sdc = tau15.stem().string() + ".sdc";
+  ot::filesystem::path timing = tau15.stem().string() + ".timing";
+  ot::filesystem::path sdc = tau15.stem().string() + ".sdc";
   timing_to_sdc(timing, sdc);
   
   // Open shell output 
@@ -212,9 +212,9 @@ int main(int argc, char* argv[]) {
 
   ot::ArgParse app {"ot-utility"};
 
-  std::vector<std::filesystem::path> t2s;
-  std::vector<std::filesystem::path> o2s;
-  std::vector<std::filesystem::path> spef;
+  std::vector<ot::filesystem::path> t2s;
+  std::vector<ot::filesystem::path> o2s;
+  std::vector<ot::filesystem::path> spef;
 
   app.add_option("--timing-to-sdc", t2s, "convert a TAU15 timing file to sdc format")
      ->expected(2);

--- a/ot/headerdef.hpp
+++ b/ot/headerdef.hpp
@@ -63,10 +63,6 @@
 // Top header declaration.
 #include <ot/config.hpp>
 
-namespace std {
-  namespace filesystem = experimental::filesystem;
-};
-
 namespace ot {
 
 using Json = nlohmann::json;
@@ -75,6 +71,7 @@ using Json = nlohmann::json;
 
 using namespace std::chrono_literals;
 using namespace std::literals::string_literals;
+namespace filesystem = std::experimental::filesystem;
 
 enum Split {
   MIN = 0,

--- a/ot/liberty/celllib.cpp
+++ b/ot/liberty/celllib.cpp
@@ -589,7 +589,7 @@ Cell Celllib::_extract_cell(token_iterator& itr, const token_iterator end) {
 }
 
 // Procedure: read
-void Celllib::read(const std::filesystem::path& path) {
+void Celllib::read(const ot::filesystem::path& path) {
   
   std::ifstream ifs(path, std::ios::ate);
   

--- a/ot/liberty/celllib.hpp
+++ b/ot/liberty/celllib.hpp
@@ -55,7 +55,7 @@ struct Celllib {
   std::unordered_map<std::string, LutTemplate> lut_templates;
   std::unordered_map<std::string, Cell> cells;
 
-  void read(const std::filesystem::path&);
+  void read(const ot::filesystem::path&);
   void scale_time(float);
   void scale_resistance(float);
   void scale_power(float);

--- a/ot/sdc/sdc.cpp
+++ b/ot/sdc/sdc.cpp
@@ -3,17 +3,17 @@
 namespace ot::sdc {
 
 // Function: home
-std::filesystem::path home() {
+ot::filesystem::path home() {
   
-  auto path = std::filesystem::path(OT_HOME) / "ot" / "sdc";
+  auto path = ot::filesystem::path(OT_HOME) / "ot" / "sdc";
 
-  if(std::filesystem::exists(path)) {
+  if(ot::filesystem::exists(path)) {
     return path;
   }
 
-  path = std::filesystem::path(OT_INSTALL_PREFIX) / "include" / "ot" / "sdc";
+  path = ot::filesystem::path(OT_INSTALL_PREFIX) / "include" / "ot" / "sdc";
 
-  if(std::filesystem::exists(path)) {
+  if(ot::filesystem::exists(path)) {
     return path;
   }
   
@@ -21,20 +21,20 @@ std::filesystem::path home() {
 }
 
 // Procedure: read
-void SDC::read(const std::filesystem::path& path) {
+void SDC::read(const ot::filesystem::path& path) {
 
-  OT_LOGE_RIF(!std::filesystem::exists(path), "sdc ", path, " doesn't exist");
+  OT_LOGE_RIF(!ot::filesystem::exists(path), "sdc ", path, " doesn't exist");
 
   auto sdc_home = home();
 
   OT_LOGE_RIF(
-    sdc_home.empty() || !std::filesystem::exists(sdc_home), 
+    sdc_home.empty() || !ot::filesystem::exists(sdc_home), 
     "sdc home ", sdc_home, " doesn't exist"
   );
   
   OT_LOGI("loading sdc ", path, " ...");
 
-  auto sdc_path = std::filesystem::absolute(path);
+  auto sdc_path = ot::filesystem::absolute(path);
   auto sdc_json = sdc_path;
   sdc_json.replace_extension(".json");
     
@@ -113,7 +113,7 @@ void SDC::read(const std::filesystem::path& path) {
     }
 
     try {
-      std::filesystem::remove(sdc_json);
+      ot::filesystem::remove(sdc_json);
     }
     catch(const std::exception& e) {
       OT_LOGW("can't remove ", sdc_json, ": ", e.what());

--- a/ot/sdc/sdc.hpp
+++ b/ot/sdc/sdc.hpp
@@ -7,7 +7,7 @@
 namespace ot::sdc {
 
 // Function: home
-std::filesystem::path home();
+ot::filesystem::path home();
 
 // SetInputDelay
 struct SetInputDelay {
@@ -142,7 +142,7 @@ using Command = std::variant<
 // Class: SDC
 struct SDC {
   std::vector<Command> commands;
-  void read(const std::filesystem::path&);
+  void read(const ot::filesystem::path&);
 };
 
 };  // end of namespace ot::sdc. ------------------------------------------------------------------

--- a/ot/shell/builder.cpp
+++ b/ot/shell/builder.cpp
@@ -81,7 +81,7 @@ void Shell::_set_num_threads() {
 
 // Procedure: read_verilog
 void Shell::_read_verilog() {
-  if(std::filesystem::path path; _is >> path) {
+  if(ot::filesystem::path path; _is >> path) {
     _timer.read_verilog(std::move(path));
   }
 }
@@ -90,7 +90,7 @@ void Shell::_read_verilog() {
 
 // Procedure: read_spef
 void Shell::_read_spef() {
-  if(std::filesystem::path path; _is >> path) {
+  if(ot::filesystem::path path; _is >> path) {
     _timer.read_spef(std::move(path));
   }
 }
@@ -99,7 +99,7 @@ void Shell::_read_spef() {
 
 // Procedure: read_timing
 void Shell::_read_timing() {
-  if(std::filesystem::path path; _is >> path) {
+  if(ot::filesystem::path path; _is >> path) {
     _timer.read_timing(std::move(path));
   }
 }
@@ -110,7 +110,7 @@ void Shell::_read_timing() {
 void Shell::_read_celllib() {
 
   std::string token;
-  std::filesystem::path path;
+  ot::filesystem::path path;
   std::optional<Split> el;
 
   while(_is >> token) {
@@ -130,7 +130,7 @@ void Shell::_read_celllib() {
 
 // Procedure: read_sdc
 void Shell::_read_sdc() {
-  if(std::filesystem::path path; _is >> path) {
+  if(ot::filesystem::path path; _is >> path) {
     _timer.read_sdc(std::move(path));
   }
 }

--- a/ot/shell/dump.cpp
+++ b/ot/shell/dump.cpp
@@ -102,7 +102,7 @@ For more information, consult the manual at\n\
 void Shell::_dump_timer() {
 
   std::string token;
-  std::filesystem::path output;
+  ot::filesystem::path output;
 
   while(_is >> token) {
     if(token == "-o") {
@@ -130,7 +130,7 @@ void Shell::_dump_timer() {
 void Shell::_dump_taskflow() {
 
   std::string token;
-  std::filesystem::path output;
+  ot::filesystem::path output;
 
   while(_is >> token) {
     if(token == "-o") {
@@ -158,7 +158,7 @@ void Shell::_dump_taskflow() {
 void Shell::_dump_graph() {
 
   std::string token;
-  std::filesystem::path output;
+  ot::filesystem::path output;
 
   while(_is >> token) {
     if(token == "-o") {
@@ -188,7 +188,7 @@ void Shell::_dump_graph() {
 void Shell::_dump_net_load() {
 
   std::string token;
-  std::filesystem::path output;
+  ot::filesystem::path output;
 
   while(_is >> token) {
     if(token == "-o") {
@@ -221,7 +221,7 @@ void Shell::_dump_net_load() {
 void Shell::_dump_pin_cap() {
 
   std::string token;
-  std::filesystem::path output;
+  ot::filesystem::path output;
 
   while(_is >> token) {
     if(token == "-o") {
@@ -254,7 +254,7 @@ void Shell::_dump_pin_cap() {
 void Shell::_dump_slack() {
 
   std::string token;
-  std::filesystem::path output;
+  ot::filesystem::path output;
 
   while(_is >> token) {
     if(token == "-o") {
@@ -285,7 +285,7 @@ void Shell::_dump_slack() {
 void Shell::_dump_rat() {
 
   std::string token;
-  std::filesystem::path output;
+  ot::filesystem::path output;
 
   while(_is >> token) {
     if(token == "-o") {
@@ -316,7 +316,7 @@ void Shell::_dump_rat() {
 void Shell::_dump_slew() {
 
   std::string token;
-  std::filesystem::path output;
+  ot::filesystem::path output;
 
   while(_is >> token) {
     if(token == "-o") {
@@ -347,7 +347,7 @@ void Shell::_dump_slew() {
 void Shell::_dump_at() {
 
   std::string token;
-  std::filesystem::path output;
+  ot::filesystem::path output;
 
   while(_is >> token) {
     if(token == "-o") {
@@ -382,7 +382,7 @@ void Shell::_dump_celllib() {
   std::string token;
   std::string cell;
   Split el = MIN;
-  std::filesystem::path output;
+  ot::filesystem::path output;
 
   while(_is >> token) {
     if(token == "-o") {
@@ -435,7 +435,7 @@ void Shell::_dump_verilog() {
 
   std::string token;
   std::string name;
-  std::filesystem::path output;
+  ot::filesystem::path output;
 
   while(_is >> token) {
     if(token == "-o") {
@@ -476,7 +476,7 @@ void Shell::_dump_verilog() {
 void Shell::_dump_spef() {
 
   std::string token;
-  std::filesystem::path output;
+  ot::filesystem::path output;
 
   while(_is >> token) {
     if(token == "-o") {
@@ -511,7 +511,7 @@ void Shell::_dump_spef() {
 void Shell::_dump_rctree() {
 
   std::string token;
-  std::filesystem::path output;
+  ot::filesystem::path output;
 
   while(_is >> token) {
     if(token == "-o") {

--- a/ot/shell/obselete.cpp
+++ b/ot/shell/obselete.cpp
@@ -17,7 +17,7 @@ void Shell::_set_early_celllib_fpath() {
   OT_LOGW(
     std::quoted("set_early_celllib_fpath"), " is obselete; use ", std::quoted("read_celllib") 
   );
-  if(std::filesystem::path path; _is >> path) {
+  if(ot::filesystem::path path; _is >> path) {
     _timer.read_celllib(std::move(path), MIN);
   }
 }
@@ -27,7 +27,7 @@ void Shell::_set_late_celllib_fpath() {
   OT_LOGW(
     std::quoted("set_late_celllib_fpath"), " is obselete; use ", std::quoted("read_celllib")
   );
-  if(std::filesystem::path path; _is >> path) {
+  if(ot::filesystem::path path; _is >> path) {
     _timer.read_celllib(std::move(path), MAX);
   }
 }
@@ -37,7 +37,7 @@ void Shell::_set_verilog_fpath() {
   OT_LOGW(
     std::quoted("set_verilog_fpath"), " is obselete; use ", std::quoted("read_verilog")
   );
-  if(std::filesystem::path path; _is >> path) {
+  if(ot::filesystem::path path; _is >> path) {
     _timer.read_verilog(std::move(path));
   }
 }
@@ -47,7 +47,7 @@ void Shell::_set_spef_fpath() {
   OT_LOGW(
     std::quoted("set_spef_fpath"), " is obselete; use ", std::quoted("read_spef")
   );
-  if(std::filesystem::path path; _is >> path) {
+  if(ot::filesystem::path path; _is >> path) {
     _timer.read_spef(std::move(path));
   }
 }
@@ -57,7 +57,7 @@ void Shell::_set_timing_fpath() {
   OT_LOGW(
     std::quoted("set_timing_fpath"), " is obselete; use ", std::quoted("read_timing")
   );
-  if(std::filesystem::path path; _is >> path) {
+  if(ot::filesystem::path path; _is >> path) {
     _timer.read_timing(std::move(path));
   }
 }

--- a/ot/shell/prompt.hpp
+++ b/ot/shell/prompt.hpp
@@ -43,16 +43,11 @@
 #include <experimental/filesystem>
 #include <cassert>
 
-
-namespace std {
-
-namespace filesystem = experimental::filesystem;
-
-};
-
 // ------------------------------------------------------------------------------------------------
 
 namespace prompt {
+
+namespace filesystem = std::experimental::filesystem;
 
 // Procedure: read_line
 // Read one line from an input stream
@@ -468,7 +463,7 @@ class Prompt {
     //Prompt(
     //  const std::string&,   // Welcome message 
     //  const std::string&,   // prompt
-    //  const std::filesystem::path& = std::filesystem::current_path()/".prompt_history",  // history log path
+    //  const filesystem::path& = filesystem::current_path()/".prompt_history",  // history log path
     //  std::istream& = std::cin, 
     //  std::ostream& = std::cout, 
     //  std::ostream& = std::cerr,
@@ -479,7 +474,7 @@ class Prompt {
     Prompt(
       const std::string&,   // Welcome message 
       const std::string&,   // prompt
-      const std::filesystem::path& = std::filesystem::current_path()/".prompt_history",  // history log path
+      const filesystem::path& = filesystem::current_path()/".prompt_history",  // history log path
       FILE* = stdin,
       std::ostream& = std::cout,
       std::ostream& = std::cerr
@@ -497,7 +492,7 @@ class Prompt {
   private: 
   
     std::string _prompt;  
-    std::filesystem::path _history_path;
+    filesystem::path _history_path;
     
     // TODO: replace these with FILE* _is, _os, _es;
     // fix inserters and extractors
@@ -547,15 +542,15 @@ class Prompt {
     void _autocomplete_command();
     void _autocomplete_folder();
 
-    std::vector<std::string> _files_in_folder(const std::filesystem::path&) const;
-    std::vector<std::string> _files_match_prefix(const std::filesystem::path&) const;
-    std::string _dump_files(const std::vector<std::string>&, const std::filesystem::path&);
+    std::vector<std::string> _files_in_folder(const filesystem::path&) const;
+    std::vector<std::string> _files_match_prefix(const filesystem::path&) const;
+    std::string _dump_files(const std::vector<std::string>&, const filesystem::path&);
     std::string _dump_options(const std::vector<std::string>&);
     std::string _next_prefix(const std::vector<std::string>&, const size_t);
 
 
-    std::filesystem::path _user_home() const;
-    bool _has_read_access(const std::filesystem::path&) const;
+    filesystem::path _user_home() const;
+    bool _has_read_access(const filesystem::path&) const;
 
     // Key handling subroutine
     void _key_backspace(LineInfo&);
@@ -582,7 +577,7 @@ inline void Prompt::LineInfo::operator = (const LineInfo& l){
 //inline Prompt::Prompt(
 //  const std::string& welcome_msg, 
 //  const std::string& pmt, 
-//  const std::filesystem::path& path,
+//  const filesystem::path& path,
 //  std::istream& in, 
 //  std::ostream& out, 
 //  std::ostream& err,
@@ -598,8 +593,8 @@ inline void Prompt::LineInfo::operator = (const LineInfo& l){
 //  if(::isatty(_infd)){
 //    _cout << welcome_msg;
 //    _columns = _terminal_columns();
-//    if(std::filesystem::exists(_history_path)){
-//      if(std::error_code ec; not std::filesystem::is_regular_file(_history_path, ec)){
+//    if(filesystem::exists(_history_path)){
+//      if(std::error_code ec; not filesystem::is_regular_file(_history_path, ec)){
 //        _cerr << "The history file is not a regular file\n";
 //      }
 //      else{
@@ -614,7 +609,7 @@ inline void Prompt::LineInfo::operator = (const LineInfo& l){
 inline Prompt::Prompt(
   const std::string& welcome_msg, 
   const std::string& pmt, 
-  const std::filesystem::path& path,
+  const filesystem::path& path,
   FILE* in,
   std::ostream& out, 
   std::ostream& err
@@ -629,8 +624,8 @@ inline Prompt::Prompt(
   if(::isatty(::fileno(_is))){
     _cout << welcome_msg;
     _columns = _terminal_columns();
-    if(std::filesystem::exists(_history_path)){
-      if(std::error_code ec; not std::filesystem::is_regular_file(_history_path, ec)){
+    if(filesystem::exists(_history_path)){
+      if(std::error_code ec; not filesystem::is_regular_file(_history_path, ec)){
         _cerr << "The history file is not a regular file\n";
       }
       else{
@@ -684,7 +679,7 @@ inline void Prompt::_save_history(){
 // Procedure: _load_history 
 // Load history commands from a file
 inline void Prompt::_load_history(){
-  if(std::filesystem::exists(_history_path)){
+  if(filesystem::exists(_history_path)){
     std::ifstream ifs(_history_path);
     std::string placeholder;
     while(std::getline(ifs, placeholder)){
@@ -896,18 +891,18 @@ inline size_t Prompt::_terminal_columns(){
 
 // Procedure: user_home
 // Return the home folder of user
-inline std::filesystem::path Prompt::_user_home() const{
+inline filesystem::path Prompt::_user_home() const{
   auto home = ::getenv("HOME");
   if(home == nullptr) {
     home = ::getpwuid(::getuid())->pw_dir;
   }
-  return home ? home : std::filesystem::current_path();
+  return home ? home : filesystem::current_path();
 }
 
 
 // Procedure: _has_read_access 
 // Check a file has read access grant to the user
-inline bool Prompt::_has_read_access(const std::filesystem::path &path) const {
+inline bool Prompt::_has_read_access(const filesystem::path &path) const {
   if(auto rval=::access(path.c_str(), F_OK); rval == 0){
     if(rval = ::access(path.c_str(), R_OK); rval == 0){
       return true;
@@ -1041,15 +1036,15 @@ inline void Prompt::_autocomplete_command(){
 // Procedure: _files_match_prefix
 // Find all the files in a folder that match the prefix
 inline std::vector<std::string> Prompt::_files_match_prefix(
-  const std::filesystem::path& path
+  const filesystem::path& path
 ) const {
   // Need to check in case path is a file in current folder (parent_path = "")
-  auto folder = path.filename() == path ? std::filesystem::current_path() : path.parent_path();
+  auto folder = path.filename() == path ? filesystem::current_path() : path.parent_path();
   std::string prefix(path.filename());
 
   std::vector<std::string> matches; 
-  if(std::error_code ec; _has_read_access(folder) and std::filesystem::is_directory(folder, ec)){
-    for(const auto& p: std::filesystem::directory_iterator(folder)){
+  if(std::error_code ec; _has_read_access(folder) and filesystem::is_directory(folder, ec)){
+    for(const auto& p: filesystem::directory_iterator(folder)){
       std::string fname {p.path().filename()};
       if(fname.compare(0, prefix.size(), prefix) == 0){
         matches.emplace_back(std::move(fname));
@@ -1063,13 +1058,13 @@ inline std::vector<std::string> Prompt::_files_match_prefix(
 // Procedure: _files_in_folder
 // List all files in a given folder
 inline std::vector<std::string> Prompt::_files_in_folder(
-  const std::filesystem::path& path
+  const filesystem::path& path
 ) const {
-  auto p = path.empty() ? std::filesystem::current_path() : path;
+  auto p = path.empty() ? filesystem::current_path() : path;
   std::vector<std::string> matches;
   // Check permission 
   if(_has_read_access(p)){
-    for(const auto& p: std::filesystem::directory_iterator(p)){
+    for(const auto& p: filesystem::directory_iterator(p)){
       matches.emplace_back(p.path().filename());
     }
   }
@@ -1081,7 +1076,7 @@ inline std::vector<std::string> Prompt::_files_in_folder(
 // Format the strings for pretty print in terminal.
 inline std::string Prompt::_dump_files(
   const std::vector<std::string>& v, 
-  const std::filesystem::path& path)
+  const filesystem::path& path)
 {
   if(v.empty()){
     return {};
@@ -1106,7 +1101,7 @@ inline std::string Prompt::_dump_files(
       s.append("\n\r\x1b[0K");
     }
 
-    if(std::filesystem::is_directory(path.native() + "/" + v[i], ec)){
+    if(filesystem::is_directory(path.native() + "/" + v[i], ec)){
       // A typical color code example : \033[31;1;4m 
       //   \033[ : begin of color code, 31 : red color,  1 : bold,  4 : underlined
       s.append(seq, strlen(seq));
@@ -1127,13 +1122,13 @@ inline void Prompt::_autocomplete_folder(){
   std::string s;
   size_t ws_index = _line.buf.rfind(' ', _line.cur_pos) + 1;
 
-  std::filesystem::path p(
+  filesystem::path p(
     _line.buf[ws_index] != '~' ? 
     _line.buf.substr(ws_index, _line.cur_pos - ws_index) : 
     _user_home().native() + _line.buf.substr(ws_index+1, _line.cur_pos-ws_index-1)
   );
 
-  if(std::error_code ec; p.empty() or std::filesystem::is_directory(p, ec)) {
+  if(std::error_code ec; p.empty() or filesystem::is_directory(p, ec)) {
     s = _dump_files(_files_in_folder(p), p);
   }
   else{
@@ -1145,7 +1140,7 @@ inline void Prompt::_autocomplete_folder(){
         _line.cur_pos += suffix.size();
         p += suffix;
         // Append a '/' if is a folder and not the prefix of other files
-        if(std::filesystem::is_directory(p, ec) and 
+        if(filesystem::is_directory(p, ec) and 
             std::count_if(match.begin(), match.end(), 
               [p = p.filename().native()](const auto& m)
               { return (m.size() >= p.size() and m.compare(0, p.size(), p) == 0); }) == 1){

--- a/ot/spef/spef.cpp
+++ b/ot/spef/spef.cpp
@@ -139,10 +139,10 @@ std::ostream& operator << (std::ostream& os, const Spef& spef) {
 // *C_UNIT 1 FF
 // *R_UNIT 1 KOHM
 // *L_UNIT 1 UH
-void Spef::read(const std::filesystem::path& path) {
+void Spef::read(const ot::filesystem::path& path) {
   
   OT_LOGE_RIF(
-    path.empty() || !std::filesystem::exists(path),
+    path.empty() || !ot::filesystem::exists(path),
     "spef ", path, " doesn't exist"
   );
 

--- a/ot/spef/spef.hpp
+++ b/ot/spef/spef.hpp
@@ -111,7 +111,7 @@ struct Spef {
 
   std::vector<Net> nets;
 
-  void read(const std::filesystem::path&);
+  void read(const ot::filesystem::path&);
   void to_capacitance_unit(const CapacitanceUnit&);
   void to_resistance_unit(const ResistanceUnit&);
 

--- a/ot/tau/tau15.cpp
+++ b/ot/tau/tau15.cpp
@@ -4,7 +4,7 @@
 namespace ot::tau15 {
 
 // Procedure: read
-void Timing::read(const std::filesystem::path& path) {
+void Timing::read(const ot::filesystem::path& path) {
   
   std::string line, token, pin;
   
@@ -66,7 +66,7 @@ void Timing::read(const std::filesystem::path& path) {
 namespace ot {
 
 // Function: read_timing
-Timer& Timer::read_timing(std::filesystem::path path) {
+Timer& Timer::read_timing(ot::filesystem::path path) {
 
   auto timing = std::make_shared<tau15::Timing>();
 

--- a/ot/tau/tau15.hpp
+++ b/ot/tau/tau15.hpp
@@ -47,7 +47,7 @@ using Assertion = std::variant<
 // Struct: Timing
 struct Timing {
   std::vector<Assertion> assertions;
-  void read(const std::filesystem::path&);
+  void read(const ot::filesystem::path&);
 };
 
 

--- a/ot/timer/celllib.cpp
+++ b/ot/timer/celllib.cpp
@@ -23,7 +23,7 @@ bool Timer::_is_redundant_timing(const Timing& timing, Split el) const {
 }
 
 // Function: read_celllib
-Timer& Timer::read_celllib(std::filesystem::path path, std::optional<Split> el) {
+Timer& Timer::read_celllib(ot::filesystem::path path, std::optional<Split> el) {
   
   auto lib = std::make_shared<Celllib>();
   

--- a/ot/timer/sdc.cpp
+++ b/ot/timer/sdc.cpp
@@ -3,7 +3,7 @@
 namespace ot {
 
 // Function: read_sdc
-Timer& Timer::read_sdc(std::filesystem::path path) {
+Timer& Timer::read_sdc(ot::filesystem::path path) {
 
   // Create a shared sdc object
   auto sdc = std::make_shared<sdc::SDC>();

--- a/ot/timer/spef.cpp
+++ b/ot/timer/spef.cpp
@@ -3,7 +3,7 @@
 namespace ot {
 
 // Function: read_spef
-Timer& Timer::read_spef(std::filesystem::path path) {
+Timer& Timer::read_spef(ot::filesystem::path path) {
 
   // Create a spefnet shared pointer
   auto spef = std::make_shared<spef::Spef>(); 

--- a/ot/timer/timer.hpp
+++ b/ot/timer/timer.hpp
@@ -35,11 +35,11 @@ class Timer {
     
     // Builder
     Timer& set_num_threads(unsigned);
-    Timer& read_celllib(std::filesystem::path, std::optional<Split> = {});
-    Timer& read_verilog(std::filesystem::path);
-    Timer& read_spef(std::filesystem::path);
-    Timer& read_sdc(std::filesystem::path);
-    Timer& read_timing(std::filesystem::path);
+    Timer& read_celllib(ot::filesystem::path, std::optional<Split> = {});
+    Timer& read_verilog(ot::filesystem::path);
+    Timer& read_spef(ot::filesystem::path);
+    Timer& read_sdc(ot::filesystem::path);
+    Timer& read_timing(ot::filesystem::path);
     Timer& insert_net(std::string);
     Timer& insert_gate(std::string, std::string);
     Timer& repower_gate(std::string, std::string);

--- a/ot/timer/verilog.cpp
+++ b/ot/timer/verilog.cpp
@@ -3,7 +3,7 @@
 namespace ot {
 
 // Function: read_verilog
-Timer& Timer::read_verilog(std::filesystem::path path) {
+Timer& Timer::read_verilog(ot::filesystem::path path) {
   
   // Create a verilog module
   auto module = std::make_shared<vlog::Module>();

--- a/ot/traits.hpp
+++ b/ot/traits.hpp
@@ -18,6 +18,7 @@
 #include <any>
 #include <unordered_map>
 #include <unordered_set>
+#include <optional>
 
 //-------------------------------------------------------------------------------------------------
 // Functors.

--- a/ot/utility/os.cpp
+++ b/ot/utility/os.cpp
@@ -3,7 +3,7 @@
 namespace ot {
 
 // Function: user_home
-std::filesystem::path user_home() {
+ot::filesystem::path user_home() {
 
   auto home = ::getenv("HOME");
 
@@ -11,7 +11,7 @@ std::filesystem::path user_home() {
     home = ::getpwuid(::getuid())->pw_dir;
   }
 
-  return home ? home : std::filesystem::current_path();
+  return home ? home : ot::filesystem::current_path();
 }
 
 // Function: c_args

--- a/ot/utility/os.hpp
+++ b/ot/utility/os.hpp
@@ -10,14 +10,12 @@
 #include <pwd.h>
 #include <experimental/filesystem>
 
-namespace std {
-  namespace filesystem = experimental::filesystem;
-};
-
 namespace ot {
 
+namespace filesystem = std::experimental::filesystem;
+
 // Function: user_home
-std::filesystem::path user_home();
+filesystem::path user_home();
 
 // Function: c_args
 std::unique_ptr<char*, std::function<void(char**)>> c_args(const std::vector<std::string>&);

--- a/ot/utility/tokenizer.cpp
+++ b/ot/utility/tokenizer.cpp
@@ -81,7 +81,7 @@ std::vector<std::string> split(const std::string& str, std::string_view dels) {
 
 // Function: tokenize:
 std::vector<std::string> tokenize(
-  const std::filesystem::path& path, 
+  const ot::filesystem::path& path, 
   std::string_view dels,
   std::string_view exps
 ) {

--- a/ot/utility/tokenizer.hpp
+++ b/ot/utility/tokenizer.hpp
@@ -10,11 +10,9 @@
 #include <regex>
 #include <experimental/filesystem>
 
-namespace std {
-  namespace filesystem = experimental::filesystem;
-};
-
 namespace ot {
+
+namespace filesystem = std::experimental::filesystem;
 
 // string conversion
 std::string to_lower(std::string);
@@ -127,7 +125,7 @@ auto on_next_parentheses(const I b, const I e, C&& c) {
 
 
 // Function: tokenize
-std::vector<std::string> tokenize(const std::filesystem::path&, std::string_view="", std::string_view="");
+std::vector<std::string> tokenize(const filesystem::path&, std::string_view="", std::string_view="");
 
 // Function: split
 std::vector<std::string> split(const std::string&, std::string_view="");

--- a/ot/verilog/verilog.cpp
+++ b/ot/verilog/verilog.cpp
@@ -69,7 +69,7 @@ std::string Module::info() const {
 }
 
 // Procedure: read_verilog
-Module read_verilog(const std::filesystem::path& path) {
+Module read_verilog(const ot::filesystem::path& path) {
 
   Module module;
   

--- a/ot/verilog/verilog.hpp
+++ b/ot/verilog/verilog.hpp
@@ -35,7 +35,7 @@ std::ostream& operator << (std::ostream&, const Module&);
 
 // ------------------------------------------------------------------------------------------------
 
-Module read_verilog(const std::filesystem::path&);
+Module read_verilog(const ot::filesystem::path&);
 
 };  // end of namespace ot. -----------------------------------------------------------------------
 


### PR DESCRIPTION
The first commit is a missing include and hopefully uncontroversial.

The second commit fixes the build on compilers where `std::filesystem` already exists, by aliasing `ot::filesystem` to `std::experimental::filesystem` rather than attempting to overwrite `std::filesystem` which produces an error in this case.

I think this should fix #41, too.