### PR TITLE
add appleclang option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "6.0")
     message(FATAL_ERROR "\nOpenTimer requires clang++ at least v6.0")
   endif() 
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
 else()
   message(FATAL_ERROR "\n\
 OpenTimer currently supports the following compilers:\n\
@@ -166,7 +167,9 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/bin)
 list(APPEND OT_LINK_FLAGS "")
 list(APPEND OT_LINK_FLAGS OpenTimer)
 list(APPEND OT_LINK_FLAGS Threads::Threads)
-list(APPEND OT_LINK_FLAGS stdc++fs)
+if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "10.0")
+  list(APPEND OT_LINK_FLAGS stdc++fs)
+endif()
 message(STATUS "OT_LINK_FLAGS: ${OT_LINK_FLAGS}")
 
 # tau15

--- a/ot/headerdef.hpp
+++ b/ot/headerdef.hpp
@@ -49,7 +49,11 @@
 // https://gcc.gnu.org/viewcvs/gcc?view=revision&revision=258854
 // to get rid of this.
 #if defined(__clang__)
+#if __clang_major__ > 12
+  #include <variant>
+#else
   #include <ot/patch/clang_variant.hpp>
+#endif
 #else
   #include <variant>
 #endif


### PR DESCRIPTION
The current OpenTimer was not compiling in macos with M1.

(Also, the stdc++lib does not seem to be needed in latest gcc/clang)